### PR TITLE
Reduce memory usage and allow shared language model in a single module file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Experiments
+.history/

--- a/PassivePyCode/PassivePySrc/PassivePy.py
+++ b/PassivePyCode/PassivePySrc/PassivePy.py
@@ -4,7 +4,7 @@ import spacy
 from termcolor import colored
 import regex as re
 from itertools import chain 
-import os, sys, gc
+import os, sys, g
 
 
 try: 
@@ -26,7 +26,7 @@ class PassivePyAnalyzer:
             save the output to a file
 
         """
-        def __init__(self, spacy_model = "en_core_web_lg"):
+        def __init__(self, nlp:spacy.language.Language=None, spacy_model:str = "en_core_web_lg"):
 
             """
             Create the Detector
@@ -37,7 +37,7 @@ class PassivePyAnalyzer:
             
             
             """
-            self.nlp, self.matcher = create_matcher(spacy_model)
+            self.nlp, self.matcher = create_matcher(nlp=nlp, spacy_model=spacy_model)
             self.matcher_t = create_matcher_truncated(self.nlp)
             self.matcher_f = create_matcher_full(self.nlp)
 

--- a/PassivePyCode/PassivePySrc/PassivePy.py
+++ b/PassivePyCode/PassivePySrc/PassivePy.py
@@ -4,7 +4,7 @@ import spacy
 from termcolor import colored
 import regex as re
 from itertools import chain 
-import os, sys, g
+import os, sys
 
 
 try: 

--- a/PassivePyCode/PassivePySrc/rules_for_all_passives.py
+++ b/PassivePyCode/PassivePySrc/rules_for_all_passives.py
@@ -1,12 +1,21 @@
 import spacy
 from spacy.matcher import Matcher
 
-
-
-def create_matcher(spacy_model = "en_core_web_lg"):
+def create_matcher(nlp:spacy.language.Language = None, spacy_model = "en_core_web_lg"):
 
     """creates a matcher on the following vocabulary"""
-    nlp = spacy.load(spacy_model, disable=["ner"])
+    if not nlp:
+        if spacy_model == "en_core_web_lg":
+            import en_core_web_lg
+            nlp = en_core_web_lg.load(disable=["ner"])
+        elif spacy_model == "en_core_web_md":
+            import en_core_web_md
+            nlp = en_core_web_md.load(disable=["ner"])
+        elif spacy_model == "en_core_web_sm":
+            import en_core_web_sm
+            nlp = en_core_web_sm.load(disable=["ner"])
+        else:
+            nlp = spacy.load(spacy_model, disable=["ner"])
     matcher = Matcher(nlp.vocab)
 
     # list of verbs that their adjective form 


### PR DESCRIPTION
Two substantive changes:

1. Make the `nlp` object a parameter, so it can be created only once in projects that have multiple uses for a single language model (the en_lg model takes up about 1 GB of memory per instance, a lot for an AWS VM)
2. Use the module import method for at least the most common imports instead of passing a string, which can reduce memory by 60% in some quick tests.

We've been experimenting with using the PassivePy project in a larger research/practice project: https://github.com/SuffolkLITLab/FormFyxer/

But we've run into an issue with memory usage. We did a few experiments and have found that using `import en_core_web_lg` and then `en_core_web_lg.load()` directly instead of passing a string can reduce memory usage by 60%. 

We're also hoping to further reduce memory usage by being able to import just one copy of the `nlp` object for the multiple places we'll be using it, since this isn't a native feature of `spacy` and we might end up with this `passivepy` object being created in multiple threads.

If this PR isn't welcome, we can fork--just wanted to see if we can work to get this upstream, since this is a really nice implementation otherwise!

See our internal discussion here: https://github.com/SuffolkLITLab/FormFyxer/pull/70